### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You will need a source code version of CPython. To run for Free Threaded Python,
 you will require CPython 3.13 and compile as 3.13t. This code will also compile under 3.12 but then you only get the
 GIL version.
 
-Please ensure you are in a virtual environment. If you cannot, or do not wish to do this then you will need to coomment
+Please ensure you are in a virtual environment. If you cannot, or do not wish to do this then you will need to comment
 out the call to check_env() in setup.py.
 
 Once you have everything in place, please execute setup.py as a python script:

--- a/_test_weave.c
+++ b/_test_weave.c
@@ -83,7 +83,7 @@ static void test_destructor_add_2(void* addr) {
 
 /* Returns a Python integer that represents whether or not the destructor was
  * properly called with the correct value. If it was not, an error is raised.
- * Otherwise it returns the nubmer of times the destructor was called.
+ * Otherwise it returns the number of times the destructor was called.
  */
 static PyObject* test_weave_get_destructor_called_1(
     PyObject* Py_UNUSED(self),
@@ -107,7 +107,7 @@ static PyObject* test_weave_get_destructor_called_1(
 
 /* Returns a Python integer that represents whether or not the second destructor
  * was properly called with the correct value. If it was not, an error is
- * raised. Otherwise it returns the nubmer of times the destructor was called.
+ * raised. Otherwise it returns the number of times the destructor was called.
  */
 static PyObject* test_weave_get_destructor_called_2(
     PyObject* Py_UNUSED(self),

--- a/_weave.c
+++ b/_weave.c
@@ -3,7 +3,7 @@
 #include "ft_compat.h"
 #include "ft_weave.h"
 
-/* Thead local storge definition.
+/* Thead local storage definition.
    ==============================
 */
 
@@ -238,7 +238,7 @@ void wvls_destructors_invoke(void* arg) {
   wvls_destructor_node_t* node = (wvls_destructor_node_t*)arg;
 
   /* Reverse the linked list to ensure destructor calling order matched
-     destrutor registration order. */
+     destructor registration order. */
   wvls_destructor_node_t* previous = NULL;
   while (node) {
     wvls_destructor_node_t* next_node = node->next;

--- a/benchmark_utils.py
+++ b/benchmark_utils.py
@@ -21,7 +21,7 @@ _BATCH_RAND = BatchExecutor(lambda: random.getrandbits(32), 1024)
 
 
 # Use these for random manipulations as they are much more performant
-# in FTPython under contention thant the random.* alternatives.
+# in FTPython under contention than the random.* alternatives.
 def ft_randint(a: int, b: int) -> int:
     if a > b:
         a, b = b, a

--- a/docs/concurrency_api.md
+++ b/docs/concurrency_api.md
@@ -230,7 +230,7 @@ A concurrent queue that allows multiple threads to push and pop values.
 *   `empty()`: Returns True if the queue is empty, False otherwise.
 
 ### Exceptions
-*   `ShutDown` raised to indicate the ConcurrentQueue is shutdown. In Python 3.13 and above `queue.ShutDown` is a type and this Exception will be an aliase for it. In earlier versions of Python concurrent defines its own ShutDown type to allow backward compatibility.
+*   `ShutDown` raised to indicate the ConcurrentQueue is shutdown. In Python 3.13 and above `queue.ShutDown` is a type and this Exception will be an alias for it. In earlier versions of Python concurrent defines its own ShutDown type to allow backward compatibility.
 *   'Empty' raised to indicate a pop/get operation timed out. This is the same as queue.Empty.
 
 ### Notes
@@ -242,7 +242,7 @@ A concurrent queue that allows multiple threads to push and pop values.
 
 #### Lock-Free Implementation
 
-The lock-free implementation of the queue uses a combination of atomic operations and careful synchronization to ensure thread safety without the need for locks. This approach can provide better performance and scalability in certain scenarios, particularly those with a large number of readers and writers. It will tend to consume more CPU in lightly loaded contitions than using the lock based approach.
+The lock-free implementation of the queue uses a combination of atomic operations and careful synchronization to ensure thread safety without the need for locks. This approach can provide better performance and scalability in certain scenarios, particularly those with a large number of readers and writers. It will tend to consume more CPU in lightly loaded conditions than using the lock based approach.
 
 In general, the lock-free implementation is recommended for scenarios where:
 

--- a/docs/fine_grained_synchronization.md
+++ b/docs/fine_grained_synchronization.md
@@ -122,7 +122,7 @@ with cython.critical_section(my_object):
 ```
 
 The below is from the batch executor source code in ft_utils where a critical sections protects the refilling of the buffer. Note how the critical section
-protects the excution on a per-object basis compare to a mutex which would just be one a code block basis.
+protects the execution on a per-object basis compare to a mutex which would just be one a code block basis.
 ```c
     Py_BEGIN_CRITICAL_SECTION(self);
     index = _Py_atomic_load_ssize(&(self->index));
@@ -447,8 +447,8 @@ However:
 This makes it useful for compute kernels, not general Python concurrency.
 
 ## Closing Thoughts
-Most concurrency libraries try to protect you. FTPython with ft_utils does something different; it gives you the control you need to design for correctness, rather than depending on global serialization as a crutch. Not only that, it makes key things easy to get right and provides library support of scalability and inter-thread communication. For example, lower level languages like C will crash if something is not thread say, FTPython will not crash, it might give an unexpected result but it keeps on trucking. When you hit issues ft_utils can provide more sophisticated synchronisation like readers/write locks, atomics and ConcurrentDict to tidy up thread correctness without a big performace hit.
+Most concurrency libraries try to protect you. FTPython with ft_utils does something different; it gives you the control you need to design for correctness, rather than depending on global serialization as a crutch. Not only that, it makes key things easy to get right and provides library support of scalability and inter-thread communication. For example, lower level languages like C will crash if something is not thread say, FTPython will not crash, it might give an unexpected result but it keeps on trucking. When you hit issues ft_utils can provide more sophisticated synchronisation like readers/write locks, atomics and ConcurrentDict to tidy up thread correctness without a big performance hit.
 
-Unitl now, Python has never been suitable for finely tuned concurrent systems. With FTP and ft_utils, that changes. You get the primitives—now you decide how to build with them.
+Until now, Python has never been suitable for finely tuned concurrent systems. With FTP and ft_utils, that changes. You get the primitives—now you decide how to build with them.
 
 If you're working on systems where performance, determinism, or mixed-criticality scheduling matter, this is finally a Python that respects your intent.

--- a/docs/ft_worked_examples.md
+++ b/docs/ft_worked_examples.md
@@ -88,7 +88,7 @@ The Python runtime compiles this code into bytecode so let's look at the bytecod
 10 RETURN_VALUE
 ```
 
-In theory the GIL can switch threads at any point between these bytecodes. Most of the time it will not because this is a very short piece of code and because in the example code it is run at the start of a thread. However, in a production system issues like interupt handing or having the program swapped out or stopped (SIGSTOP) could easly cause a thread swap between bytecodes. Consider what happens if we get a thread swap between 4 and 6? This could result in a different thread updating `result` only to have its update overwritten.
+In theory the GIL can switch threads at any point between these bytecodes. Most of the time it will not because this is a very short piece of code and because in the example code it is run at the start of a thread. However, in a production system issues like interrupt handing or having the program swapped out or stopped (SIGSTOP) could easily cause a thread swap between bytecodes. Consider what happens if we get a thread swap between 4 and 6? This could result in a different thread updating `result` only to have its update overwritten.
 
 **Be warned that programs which appear consistent and atomic due to the GIL often become unstable in complex production systems.**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,8 +28,8 @@ Welcome to the documentation for Free Threaded Python and the ft_utils library. 
 
 The `ft_utils.ENABLE_EXPERIMENTAL` flag defaults to False. When set to True some features are made available which are not fully supported and/or not fully backward compatible. The flag must be set before trying to use these features for the first time because of caching.
 
-## On Github
+## On GitHub
 
-* [Source on github](https://github.com/facebookincubator/ft_utils)
+* [Source on GitHub](https://github.com/facebookincubator/ft_utils)
 * [License - MIT](https://github.com/facebookincubator/ft_utils/blob/main/LICENSE)
 * [Readme](https://github.com/facebookincubator/ft_utils/blob/main/README.md)

--- a/docs/weave_api.md
+++ b/docs/weave_api.md
@@ -12,7 +12,7 @@ The following two functions are intended to be called from native code (see `ft_
 
 ## Native API
 
-`ft_weave.h` provides a header only implementation which in conjuction with having weave imported into the Python VM will permit access to weave's advanced threading features. The functions in the header will attempt to import ft_utils.weave if required.
+`ft_weave.h` provides a header only implementation which in conjunction with having weave imported into the Python VM will permit access to weave's advanced threading features. The functions in the header will attempt to import ft_utils.weave if required.
 
 * `weave_local`: A type modifier to mark a variable as using thread local storage. This name was chosen to avoid clashing with names such as thread_local in thread.h on Linux. However, when a compiler or header is used which correctly defines thread_local, then weave_local is redundant and you can use either with weave. For example `static weave_local void* tls_2 = NULL;`.
 * `typedef void (*wvls_destructor_t)(void*)`: A function called with a value of a thread local variable which is assumed to be a pointer to some structure which needs to be freed just before thread death. This function must not call into the Python interpreter in any way because we cannot guarantee any part of Python will be valid during the call.

--- a/ft_weave.h
+++ b/ft_weave.h
@@ -67,7 +67,7 @@ int unregister_wvls_destructor(void** wvls_variable_ptr);
 
 /* Below we have a number of static methods which is unusual in a header. The
    reason is to avoid linking between shared objects and/or multiple different
-   defintions of the methods at link time. This approach ensures each
+   definitions of the methods at link time. This approach ensures each
    translation unit has its own version of the functions and these are not
    visible outside the translation unit at link time. */
 
@@ -99,7 +99,7 @@ static inline PyObject* _py_get_function(
   return pFunc;
 }
 
-/* A function to call from the C ABI which will use the Python interpretor to
+/* A function to call from the C ABI which will use the Python interpreter to
    register a destructor. This allow the use of this header only in other
    modules and prevents inter-extension runtime communication other than through
    Python itself.  Returns zero on success, one on failure.*/

--- a/local.c
+++ b/local.c
@@ -436,7 +436,7 @@ static PyObject* LocalWrapper_index(LocalWrapperObject* self) {
   return PyNumber_Index(self->wrapped);
 }
 
-/* Matrix multplication is rare and complex so just let the
+/* Matrix multiplication is rare and complex so just let the
    interpreter handle it. This will cause ref counting on the
    stack so we can address this if we see issues. */
 static PyObject* LocalWrapper_matrix_multiply(
@@ -953,7 +953,7 @@ static struct PyModuleDef_Slot module_slots[] = {
 static PyModuleDef local_module = {
     PyModuleDef_HEAD_INIT,
     "local",
-    "Utilies to thread localize load and store of shared data.",
+    "Utilities to thread localize load and store of shared data.",
     0,
     NULL,
     module_slots,

--- a/synchronization.c
+++ b/synchronization.c
@@ -534,7 +534,7 @@ static struct PyModuleDef_Slot module_slots[] = {
 static PyModuleDef local_module = {
     PyModuleDef_HEAD_INIT,
     "synchronization",
-    "Synchronization utilies for FTPython.",
+    "Synchronization utilities for FTPython.",
     0,
     NULL,
     module_slots,


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=ccompiler,wokr --write-changes` 

---
Unfortunately the ___Import Status___ check seems defective because it is not placated by the successful import:
% `uvx --with=git+https://github.com/cclauss/ft_utils.git@codespell python3.14t -c "import ft_utils"`