### PR TITLE
upgrading cibuildwheel version and added max parallel to help with build failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
   cibuildwheel:
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         include:
           - wheel: "linux-3.13"
@@ -61,7 +62,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.22.0
+        run: python -m pip install cibuildwheel==3.4.0
 
       - name: Build Python wheels
         run: python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
Right now some builds are failing because of too many request
```
Traceback (most recent call last):
    File "<frozen runpy>", line 198, in _run_module_as_main
    File "<frozen runpy>", line 88, in _run_code
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/cibuildwheel/__main__.py", line 430, in <module>
      main()
      ~~~~^^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/cibuildwheel/__main__.py", line 49, in main
      main_inner(global_options)
      ~~~~~~~~~~^^^^^^^^^^^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/cibuildwheel/__main__.py", line 184, in main_inner
      build_in_directory(args)
      ~~~~~~~~~~~~~~~~~~^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/cibuildwheel/__main__.py", line 351, in build_in_directory
      platform_module.build(options, tmp_path)
      ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/cibuildwheel/macos.py", line 449, in build
      base_python, env = setup_python(
                         ~~~~~~~~~~~~^
          identifier_tmp_dir / "build",
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      ...<3 lines>...
          build_frontend.name,
          ^^^^^^^^^^^^^^^^^^^^
      )
      ^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/cibuildwheel/macos.py", line 239, in setup_python
      env = virtualenv(
          python_configuration.version,
      ...<3 lines>...
          use_uv=use_uv,
      )
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/cibuildwheel/util.py", line 713, in virtualenv
      virtualenv_app = _ensure_virtualenv(version)
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/cibuildwheel/util.py", line 644, in _ensure_virtualenv
      download(url, path)
      ~~~~~~~~^^^^^^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/cibuildwheel/util.py", line 369, in download
      with urllib.request.urlopen(url, context=context) as response:
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/request.py", line 189, in urlopen
      return opener.open(url, data, timeout)
             ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/request.py", line 495, in open
      response = meth(req, response)
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/request.py", line 604, in http_response
      response = self.parent.error(
          'http', request, response, code, msg, hdrs)
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/request.py", line 533, in error
      return self._call_chain(*args)
             ~~~~~~~~~~~~~~~~^^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/request.py", line 466, in _call_chain
      result = func(*args)
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/request.py", line 613, in http_error_default
      raise HTTPError(req.full_url, code, msg, hdrs, fp)
  urllib.error.HTTPError: HTTP Error 429: Too Many Requests
```
From doing some research online it seems like if we upgrade out version of cibuildwheel this issue will be resolved becuase it handles retries for us. 